### PR TITLE
Update homepage URL in humanize.gemspec

### DIFF
--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.date = "2016-03-30"
   s.email = "radarlistener@gmail.com"
   s.files = ["README.markdown", "Rakefile", "lib/cache.rb", "lib/humanize.rb", "lib/lots.rb", "spec/TODO", "spec/humanize_spec.rb", "spec/tests.rb"]
-  s.homepage = "http://github.com/mislav/humanize"
+  s.homepage = "https://github.com/radar/humanize"
   s.rubygems_version = "2.5.1"
   s.summary = "Extension to Numeric to humanize numbers"
 end


### PR DESCRIPTION
As @radar is maintaining this gem, it makes sense to me that the home page URL on RubyGems.org should point to the right page on Github. The old URL went directly to a 404 page. This one doesn't!