### PR TITLE
Adds missing specs, fixes french specific case, installs testing tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    humanize (1.2.0)
+    humanize (1.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,104 @@
+PATH
+  remote: .
+  specs:
+    humanize (1.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abstract_type (0.0.7)
+    adamantium (0.2.0)
+      ice_nine (~> 0.11.0)
+      memoizable (~> 0.4.0)
+    anima (0.3.0)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2)
+      equalizer (~> 0.0.11)
+    ast (2.3.0)
+    byebug (9.0.6)
+    coderay (1.1.1)
+    concord (0.1.5)
+      adamantium (~> 0.2.0)
+      equalizer (~> 0.0.9)
+    diff-lcs (1.2.5)
+    equalizer (0.0.11)
+    ice_nine (0.11.2)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (0.8.2)
+    morpher (0.2.6)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.0)
+      ast (~> 2.2)
+      concord (~> 0.1.5)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.0)
+      procto (~> 0.0.2)
+    mutant (0.8.12)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.0)
+      ast (~> 2.2)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.1)
+      memoizable (~> 0.4.2)
+      morpher (~> 0.2.6)
+      parallel (~> 1.3)
+      parser (~> 2.3.1, >= 2.3.1.4)
+      procto (~> 0.0.2)
+      regexp_parser (~> 0.3.6)
+      unparser (~> 0.2.5)
+    mutant-rspec (0.8.11)
+      mutant (~> 0.8.11)
+      rspec-core (>= 3.4.0, < 3.6.0)
+    parallel (1.9.0)
+    parser (2.3.1.4)
+      ast (~> 2.2)
+    procto (0.0.3)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    regexp_parser (0.3.6)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    slop (3.6.0)
+    thread_safe (0.3.5)
+    unparser (0.2.5)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2.5)
+      equalizer (~> 0.0.9)
+      parser (~> 2.3.0)
+      procto (~> 0.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  humanize!
+  mutant
+  mutant-rspec
+  pry-byebug
+  rspec
+
+BUNDLED WITH
+   1.12.4

--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,12 @@ Currently supported locales: `:en` and `:fr`
 2. 0.120000   0.000000   0.120000 (  0.116230)
 3. 0.130000   0.000000   0.130000 (  0.122856)
 
+## Testing
+
+Install development dependencies by running `bundle install`.
+
+You can run mutation testing by calling `bin/run_mutant`.
+
 ## Credits
 
 * *Original idea*: Brenton Fletcher

--- a/bin/run_mutant
+++ b/bin/run_mutant
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mutant --include lib --require humanize --use rspec Humanize

--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -17,4 +17,7 @@ Gem::Specification.new do |s|
   s.summary = "Extension to Numeric to humanize numbers"
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'mutant'
+  s.add_development_dependency 'mutant-rspec'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -26,7 +26,7 @@ module Humanize
         sets << LOTS[locale][i] + (!sets.empty? ? (f ? ' ' + WORDS[locale][:and] : WORDS[locale][:comma]) : '') if !(r.zero? || i.zero?)
         f = true if i.zero? && r < 100
 
-        sets << SUB_ONE_THOUSAND[locale][r] if !r.zero?
+        sets << SUB_ONE_THOUSAND[locale][r] if !r.zero? && !exactly_one_thousand_in_french?(locale, r, sets)
         i = i.succ
 
       end
@@ -40,7 +40,7 @@ module Humanize
                           end
       o += ' ' + WORDS[locale][:point] + ' ' + decimals_as_words
     end
-    o
+    o.gsub(/ +/, ' ')
   end
 
   class << self
@@ -60,6 +60,10 @@ module Humanize
   end
 
 private
+
+  def exactly_one_thousand_in_french?(locale, r, sets)
+    locale == :fr && r == 1 && sets.last.to_s.strip == 'mille'
+  end
 
   class Configuration
     attr_accessor :default_locale, :decimals_as

--- a/lib/words.rb
+++ b/lib/words.rb
@@ -10,7 +10,7 @@ WORDS = {
     :negative => 'négatif',
     :zero => 'zéro',
     :point => 'virgule',
-    :and => 'et',
+    :and => '',
     :comma => ''
   }
 }

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,8 +1,7 @@
-require 'rubygems'
-require 'humanize'
-require 'rspec'
+require 'spec_helper'
 
 module Humanize
+
   describe Configuration do
 
     after(:each) do

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -25,6 +25,18 @@ describe "Humanize" do
       expect(42.humanize(:locale => :fr)).to eql('quarante-deux')
     end
 
+    describe 'french specific rules' do
+
+      it 'one thousand and one equals "mille un"' do
+        expect(1002.humanize(:locale => :fr)).to eql('mille deux')
+      end
+
+      it 'two thousand and one equals "deux mille un"' do
+        expect(2001.humanize(:locale => :fr)).to eql('deux mille un')
+      end
+
+    end
+
   end
 
   describe 'decimals_as option' do

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -27,4 +27,28 @@ describe "Humanize" do
 
   end
 
+  describe 'decimals_as option' do
+
+    it 'uses value from configuration' do
+      Humanize.config.decimals_as = :number
+      expect(0.42.humanize).to eql('zero point forty-two')
+    end
+
+    it 'uses value passed as argument if given' do
+      Humanize.config.decimals_as = :number
+      expect(0.42.humanize(:decimals_as => :digits)).to eql('zero point four two')
+    end
+
+  end
+
+  describe 'both options work together' do
+
+    it 'work together' do
+      expect(
+        0.42.humanize(:locale => :fr, :decimals_as => :number)
+      ).to eql('zéro virgule quarante-deux')
+    end
+
+  end
+
 end

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -1,6 +1,4 @@
-require 'rubygems'
-require 'humanize'
-require 'rspec'
+require 'spec_helper'
 
 describe "Humanize" do
   require_relative 'tests'

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -17,12 +17,12 @@ describe "Humanize" do
 
     it 'uses default locale' do
       Humanize.config.default_locale = :fr
-      expect(42.humanize).to eql("quarante-deux".gsub(/ +/, ' '))
+      expect(42.humanize).to eql('quarante-deux')
     end
 
     it 'uses locale passed as argument if given' do
       Humanize.config.default_locale = :en
-      expect(42.humanize(:locale => :fr)).to eql("quarante-deux".gsub(/ +/, ' '))
+      expect(42.humanize(:locale => :fr)).to eql('quarante-deux')
     end
 
   end

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -35,6 +35,10 @@ describe "Humanize" do
         expect(2001.humanize(:locale => :fr)).to eql('deux mille un')
       end
 
+      it 'ten thousand equals "dix mille"' do
+        expect(2001.humanize(:locale => :fr)).to eql('deux mille un')
+      end
+
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+require 'rubygems'
+require 'humanize'
+require 'rspec'
+require 'timeout'
+# require 'pry-byebug'
+
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    Timeout.timeout(5, &example)
+  end
+end

--- a/spec/tests.rb
+++ b/spec/tests.rb
@@ -5,6 +5,7 @@ TESTS = [
  [8, "eight"],
  [11, "eleven"],
  [21, "twenty-one"],
+ [99, "ninety-nine"],
  [100, "one hundred"],
  [101, "one hundred and one"],
  [111, "one hundred and eleven"],


### PR DESCRIPTION
After using the gem in my project I realized there was quirk with a specific french case.

`one thousand` is not translated to `un mille` in french, but rather just `mille`. So I added a condition for that particular case in that particular locale. After thinking a bit about it it might be the only specific case.

In the process I realized I did not include specs for the `decimals_as` options. So I added them.
Using mutation testing with `mutant` helped me realize I did not include the tests, so I added it to the project with a little script to simplify running it.
If you don't want to include it, tell me I'll remove the commit from the pull request.