### PR TITLE
Patch 1000 issue in Indonesian language

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -42,6 +42,11 @@ module Humanize
                           end
       o += ' ' + WORDS[locale][:point] + ' ' + decimals_as_words
     end
+    if locale == :id
+      lots = LOTS[:id].drop(2).map{|n| n + ' '}
+      wrong_1000_re = /(?<=#{lots.join("|")})\s*satu ribu|^satu ribu/
+      o.sub!(wrong_1000_re, 'seribu')
+    end
     o.gsub(/ +/, ' ')
   end
 

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -59,6 +59,26 @@ describe "Humanize" do
 
     end
 
+    describe 'indonesian specific rules' do
+      before do
+        Humanize.config.default_locale = :id
+      end
+
+      context 'one thousand' do
+        it 'equals "satu ribu" when it is not the only thousand in its thousands range' do
+          expect(1_101_000.humanize).to eql('satu juta seratus satu ribu')
+          expect(2_201_042.humanize).to eql('dua juta dua ratus satu ribu empat puluh dua')
+        end
+
+        it 'equals "seribu" when it is the lone thousand in its thousands range' do
+          expect(1_000.humanize).to eql('seribu')
+          expect(1_042.humanize).to eql('seribu empat puluh dua')
+          expect(1_001_042.humanize).to eql('satu juta seribu empat puluh dua')
+          expect(1_000_001_042.humanize).to eql('satu miliar seribu empat puluh dua')
+        end
+      end
+    end
+
   end
 
   describe 'decimals_as option' do


### PR DESCRIPTION
Hi, @radar!
There is a bug in the number `1000` in the Indonesian locale I wrote.
`1000` in Indonesian language is kind of interesting.
No other numbers possess the same behaviour.

The quirks are:
  * When it is the lone thousand in its thousands range, `satu` (one) and `ribu` (thousand) merge to become `seribu` (one thousand).
  * When it is not the lone thousand in its thousands range, `satu` and `ribu` do not merge. 
 
Other numbers are either always merge: `satu` and `puluh`(ten(s)) => `sepuluh` (ten), and `satu` and `ratus` (hundred(s)) => `seratus` (one hundred); or never merge: `satu` and `juta` (million) => `satu juta` (one million), `satu` and `miliar` (billion) => `satu miliar` (one billion), and so on.