### PR TITLE
Improve performance of extra spaces removal

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -47,7 +47,7 @@ module Humanize
       wrong_1000_re = /(?<=#{lots.join("|")})\s*satu ribu|^satu ribu/
       o.sub!(wrong_1000_re, 'seribu')
     end
-    o.gsub(/ +/, ' ')
+    o.squeeze(' ')
   end
 
   class << self


### PR DESCRIPTION
Hi, @radar.

I think I catch another thing that can be improved a little.
The `gsub` to remove extra chars (spaces in this case) can be replaced with its cousin `squeeze` that is made specifically for this.

You can test them with this:
```ruby
o = "words with   extra  spaces in the middle"
o.gsub(/ +/, ' ')
o.squeeze(' ')
Benchmark.ips do |x|
  x.config(:time => 10, :warmup => 3)

  x.report("gsub") do
    o.gsub(/ +/, ' ')
  end

  x.report("squeeze") do
    o.squeeze(' ')
  end

  x.compare!
end
```

Result:
![screen shot 2017-11-02 at 9 59 27 am](https://user-images.githubusercontent.com/8341867/32308051-5c40de98-bfb6-11e7-90bd-81bbe7f3051e.png)
