### PR TITLE
Fix issue #29 where number -0.XXX is read without the `negative`.

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -11,7 +11,7 @@ module Humanize
   def humanize(options = {})
     locale = options[:locale] || Humanize.config.default_locale
     decimals_as = options[:decimals_as] || Humanize.config.decimals_as
-    num = self.to_i
+    num = self
     o = ''
     if num < 0
       o += WORDS[locale][:negative] + ' '

--- a/spec/tests.rb
+++ b/spec/tests.rb
@@ -1,5 +1,6 @@
 TESTS = [
  [-1, "negative one"],
+ [-0.042, "negative zero point zero four two"],
  [0, "zero"],
  [8.15, "eight point one five"],
  [8, "eight"],


### PR DESCRIPTION
Hi, @radar. This should fix the issue #29 that I found.
`to_i` is not needed here since `self` is already of type `Numeric` (module is included to `Numeric`).

I also commit `Gemfile.lock` to fix the CI error.