### PR TITLE
Fix issue #31 where float conversions break after 5 decimal places

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -35,7 +35,8 @@ module Humanize
       o += sets.reverse.join(' ')
     end
     if self.class == Float
-      decimals = self.to_s.split(/\./, 2).last
+      digits, exp = to_s.split("e-")
+      decimals = ("%.#{digits[/\d+$/].length + exp.to_i}f" % self).split(/\./, 2).last
       has_leading_zeroes = decimals[/^0+/].to_s.length > 0
       decimals_as = :digits if has_leading_zeroes
       decimals_as_words = case decimals_as

--- a/spec/tests.rb
+++ b/spec/tests.rb
@@ -1,8 +1,12 @@
 TESTS = [
  [-1, "negative one"],
  [-0.042, "negative zero point zero four two"],
+ [-0.00003345, "negative zero point zero zero zero zero three three four five"],
+ [-0.0000017854, "negative zero point zero zero zero zero zero one seven eight five four"],
+ [0.000000123, "zero point zero zero zero zero zero zero one two three"],
  [0, "zero"],
  [8.15, "eight point one five"],
+ [8.000015, "eight point zero zero zero zero one five"],
  [8, "eight"],
  [11, "eleven"],
  [21, "twenty-one"],


### PR DESCRIPTION
Hi, @radar.
I think this could fix issue #31 that is caused by ruby printing floats in scientific notation after 5 decimal places.