### PR TITLE
Fix readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ Converts numbers to strings.
 All the way up to 156 digit numbers:
 
 ```ruby
-999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999.humanize
 # => "nine hundred and ninety nine quinquagintillion, nine hundred and ninety nine novenquadragintillion, nine hundred and ninety nine octoquadragintillion, nine hundred and ninety nine septenquadragintillion, nine hundred and ninety nine sesquadragintillion, nine hundred and ninety nine quinquadragintillion, nine hundred and ninety nine quattuorquadragintillion, nine hundred and ninety nine trequadragintillion, nine hundred and ninety nine duoquadragintillion, nine hundred and ninety nine unquadragintillion, nine hundred and ninety nine quadragintillion, nine hundred and ninety nine novemtrigintillion, nine hundred and ninety nine octotrigintillion, nine hundred and ninety nine septentrigintillion, nine hundred and ninety nine sextrigintillion, nine hundred and ninety nine quintrigintillion, nine hundred and ninety nine quattuortrigintillion, nine hundred and ninety nine trestrigintillion, nine hundred and ninety nine duotrigintillion, nine hundred and ninety nine untrigintillion, nine hundred and ninety nine trigintillion, nine hundred and ninety nine novemvigintillion, nine hundred and ninety nine octovigintillion, nine hundred and ninety nine septenvigintillion, nine hundred and ninety nine sexvigintillion, nine hundred and ninety nine quinvigintillion, nine hundred and ninety nine quattuortillion, nine hundred and ninety nine trevigintillion, nine hundred and ninety nine duovigintillion, nine hundred and ninety nine unvigintillion, nine hundred and ninety nine vigintillion, nine hundred and ninety nine novemdecillion, nine hundred and ninety nine octodecillion, nine hundred and ninety nine septendecillion, nine hundred and ninety nine sexdecillion, nine hundred and ninety nine quindecillion, nine hundred and ninety nine quattuordecillion, nine hundred and ninety nine tredecillion, nine hundred and ninety nine duodecillion, nine hundred and ninety nine undecillion, nine hundred and ninety nine decillion, nine hundred and ninety nine nonillion, nine hundred and ninety nine octillion, nine hundred and ninety nine septillion, nine hundred and ninety nine sextillion, nine hundred and ninety nine quintrillion, nine hundred and ninety nine quadrillion, nine hundred and ninety nine trillion, nine hundred and ninety nine billion, nine hundred and ninety nine million, nine hundred and ninety nine thousand nine hundred and ninety nine"
 ```
 
@@ -27,25 +27,37 @@ If you are dealing with numbers larger than 156 digits, we accept patches. Word 
 
 ### Install the gem using RubyGems
 
-		gem install humanize
+```bash
+gem install humanize
+```
 
-### Include it in your program or add to your Gemfile
+or:
 
-		require 'humanize'
-    # or
-    gem 'humanize'
+### Add it to your Gemfile
+
+```ruby
+gem 'humanize'
+```
+
+### Include it in your program
+
+```ruby
+require 'humanize'
+```
 
 ### Call the method on the numbers
 
-		100.humanize => "one hundred"
-		1001.humanize => "one thousand one"
-    0.001.humanize => "zero point zero zero one"
+```ruby
+100.humanize => "one hundred"
+1001.humanize => "one thousand one"
+0.001.humanize => "zero point zero zero one"
+```
 
 ## Configuration
 
 ```ruby
 Humanize.configure do |config|
-  config.default_locale = :en  # [:en, :fr, :tr, :de], default: :en
+  config.default_locale = :en  # [:en, :fr, :tr, :de, :id], default: :en
   config.decimals_as = :digits # [:digits, :number], default: :digits
 end
 ```
@@ -71,7 +83,7 @@ You can choose how you want to display decimals:
 Currently supported locales:
 
 * English: `:en`
-* French: `:fr`,
+* French: `:fr`
 * Turkish: `:tr`
 * German: `:de`
 * Indonesian: `:id`


### PR DESCRIPTION
@radar, I want to fix these on the readme:
- Call `humanize` on 9s.
- Fix install guide. It should be:  install from terminal **or** add to Gemfile and then `require` it.
- Use triple backticks (```) instead of indentations to render them nicely on github.
- Add `:id` to the list of locale in the configuration example.
- Remove trailing comma after `:fr`.

What do you think?