### PR TITLE
Support infinity and undefined

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -14,6 +14,19 @@ module Humanize
     number_grouping = WORDS[locale][:group_by]
     num = self
     o = ''
+
+    if num.class == Float
+      if (inf = num.infinite?)
+        if inf == 1
+          return WORDS[locale][:infinity]
+        else
+          return "#{WORDS[locale][:negative]} #{WORDS[locale][:infinity]}"
+        end
+      elsif num.nan?
+        return WORDS[locale][:undefined]
+      end
+    end
+
     if num.zero?
       return WORDS[locale][:zero]
     elsif num < 0

--- a/lib/humanize/words.rb
+++ b/lib/humanize/words.rb
@@ -33,8 +33,8 @@ module Humanize
     },
     :tr => {
       :group_by => 1_000,
-      :infinity => 'sonsuzluk', # needs verification
-      :undefined => 'tanımsız', # needs verification
+      :infinity => 'sonsuz',
+      :undefined => 'tanımsız',
       :negative => 'eksi',
       :zero => 'sıfır',
       :point => 'virgül',

--- a/lib/humanize/words.rb
+++ b/lib/humanize/words.rb
@@ -3,6 +3,8 @@ module Humanize
   WORDS = {
     :de => {
       :group_by => 1_000,
+      :infinity => 'Unendlichkeit', # needs verification
+      :undefined => 'undefiniert', # needs verification
       :negative => 'negativ',
       :zero => 'null',
       :point => 'Punkt',
@@ -11,6 +13,8 @@ module Humanize
     },
     :en => {
       :group_by => 1_000,
+      :infinity => 'infinity',
+      :undefined => 'undefined',
       :negative => 'negative',
       :zero => 'zero',
       :point => 'point',
@@ -19,6 +23,8 @@ module Humanize
     },
     :fr => {
       :group_by => 1_000,
+      :infinity => 'infini', # needs verification
+      :undefined => 'indéfini', # needs verification
       :negative => 'négatif',
       :zero => 'zéro',
       :point => 'virgule',
@@ -27,6 +33,8 @@ module Humanize
     },
     :tr => {
       :group_by => 1_000,
+      :infinity => 'sonsuzluk', # needs verification
+      :undefined => 'tanımsız', # needs verification
       :negative => 'eksi',
       :zero => 'sıfır',
       :point => 'virgül',
@@ -35,6 +43,8 @@ module Humanize
     },
     :id => {
       :group_by => 1_000,
+      :infinity => 'tak terhingga',
+      :undefined => 'tak terdefinisi',
       :negative => 'minus',
       :zero => 'nol',
       :point => 'koma',

--- a/lib/humanize/words.rb
+++ b/lib/humanize/words.rb
@@ -3,8 +3,8 @@ module Humanize
   WORDS = {
     :de => {
       :group_by => 1_000,
-      :infinity => 'Unendlichkeit', # needs verification
-      :undefined => 'undefiniert', # needs verification
+      :infinity => 'Unendlich',
+      :undefined => 'undefiniert',
       :negative => 'negativ',
       :zero => 'null',
       :point => 'Punkt',

--- a/lib/humanize/words.rb
+++ b/lib/humanize/words.rb
@@ -23,8 +23,8 @@ module Humanize
     },
     :fr => {
       :group_by => 1_000,
-      :infinity => 'infini', # needs verification
-      :undefined => 'indéfini', # needs verification
+      :infinity => 'infini',    # Needs verification from native french speaker. Send
+      :undefined => 'indéfini', # PR to correct (if wrong) and remove these 2 line comments.
       :negative => 'négatif',
       :zero => 'zéro',
       :point => 'virgule',

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -127,7 +127,21 @@ describe "Humanize" do
         Date::Infinity.new.humanize
       }.to raise_error(NoMethodError, /humanize/) if defined? Date::Infinity
     end
-    
+
+  end
+
+  describe 'when called on conceptual number' do
+
+    it 'reads correctly' do
+      inf = Float::INFINITY
+      neg_inf = -inf
+      nan = inf + neg_inf
+
+      expect(inf.humanize).to eql('infinity')
+      expect(neg_inf.humanize).to eql('negative infinity')
+      expect(nan.humanize).to eql('undefined')
+    end
+
   end
 
 end


### PR DESCRIPTION
@radar, instead of raising error when called on conceptual numbers, I'm thinking of supporting them.

So, instead of these:
```ruby
(1/0.0).humanize
#=> FloatDomainError: Infinity
(-1/0.0).humanize
#=> FloatDomainError: Infinity
(0/0.0).humanize
#=> FloatDomainError: NaN
```
We can do these:
```ruby
(1/0.0).humanize
#=> "infinity"
(-1/0.0).humanize
#=> "negative infinity"
(0/0.0).humanize
#=> "undefined"
```
But, first, I need @axelerator and @mertbulan to verify the words for 'undefined' and 'infinity', that I got from google translate, in German and Turkish. For French, can anyone check it?