### PR TITLE
Use keyword arguments instead of options hash

### DIFF
--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.name = "humanize"
   s.version = "1.7.0"
 
+  s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Jack Chen", "Ryan Bigg"]

--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -8,9 +8,9 @@ module Humanize
   # Big numbers are big: http://wiki.answers.com/Q/What_number_is_after_vigintillion&src=ansTT
 
 
-  def humanize(options = {})
-    locale = options[:locale] || Humanize.config.default_locale
-    decimals_as = options[:decimals_as] || Humanize.config.decimals_as
+  def humanize(locale: Humanize.config.default_locale,
+               decimals_as: Humanize.config.decimals_as)
+
     number_grouping = WORDS[locale][:group_by]
     num = self
     o = ''


### PR DESCRIPTION
Prefer to use keyword arguments to options hash for these reasons:
- Fewer characters or lines of code to type.
- We can immediately discover the names of the arguments without having to read the body of the method.
- Less chance of typos if in the future we want to add new arguments since we don’t have to write the boilerplate code to extract hash options.


Source: [Ruby 2 Keyword Arguments](https://robots.thoughtbot.com/ruby-2-keyword-arguments#keyword-arguments-vs-options-hash)