### PR TITLE
Support BigDecimal

### DIFF
--- a/lib/humanize.rb
+++ b/lib/humanize.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 require_relative './humanize/cache'
 require_relative './humanize/lots'
 require_relative './humanize/words'
@@ -133,5 +134,9 @@ class Integer
 end
 
 class Float
+  include Humanize
+end
+
+class BigDecimal
   include Humanize
 end

--- a/spec/humanize_spec.rb
+++ b/spec/humanize_spec.rb
@@ -144,4 +144,12 @@ describe "Humanize" do
 
   end
 
+  describe 'when called on bigdecimal' do
+
+    it 'reads correctly' do
+      expect(BigDecimal.new(TESTS.last.first).humanize).to eql(TESTS.last.last)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Now:
```ruby
BigDecimal.new("10").humanize
#=> "ten"
```
Before, it was `NoMethodError`. 