### PR TITLE
Autoload locales

### DIFF
--- a/lib/humanize/locales.rb
+++ b/lib/humanize/locales.rb
@@ -1,3 +1,5 @@
-%w[az de en fr id ru th tr].each do |locale|
-  require_relative "locales/#{locale}"
+module Humanize
+  %w[az de en fr id ru th tr].each do |locale|
+    autoload locale.capitalize.to_sym, "humanize/locales/#{locale}.rb"
+  end
 end


### PR DESCRIPTION
Most people usually only use one or maybe some locales, not all of them. And because it seems that `autoload`'s live has been [prolonged](https://bugs.ruby-lang.org/issues/5653#note-46), I'm thinking of `autoload`ing them to prevent loading unused locales.
