### PR TITLE
Update ruby versions and remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,13 @@
 
 language: ruby
 rvm:
-  - "2.3" # latest 2.3.x
   - "2.4" # latest 2.4.x
   - "2.5" # latest 2.5.x
+  - "2.6" # latest 2.6.x
   - "ruby-head"
 script:
   - bundle exec rspec
   - bundle exec rubocop
-
-
-sudo: false
 
 before_install:
   - gem install bundler


### PR DESCRIPTION
- No reason to test on ruby version **2.3.x**, as it's not maintained anymore
- Remove `sudo: false` because [this](https://changelog.travis-ci.com/linux-builds-run-on-vms-by-default-77106).