### PR TITLE
Drop support for ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Style/StringLiterals:
   Enabled: false
@@ -10,7 +10,7 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 200
   Exclude:
     - lib/humanize/locales/constants/*.rb

--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name = "humanize"
   s.version = "2.4.3"
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
   s.require_paths = ["lib"]
   s.authors = ["Jack Chen", "Ryan Bigg"]
   s.email = "me@ryanbigg.com"


### PR DESCRIPTION
I'm working on to contribute `:vi` locale and I realize I can't run rubocop:
```bash
$ bundle exec rubocop
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Supported versions: 2.4, 2.5, 2.6, 2.7, 3.0
```

Because [Rubocop drop support for Ruby 2.3](https://github.com/rubocop-hq/rubocop/pull/7869/files) and [support of Ruby 2.3 has ended](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/)
So I think we should update ruby version to 2.4.

