### PR TITLE
Drop support for ruby 2.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Style/StringLiterals:
   Enabled: false
@@ -10,7 +10,7 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 200
   Exclude:
     - lib/humanize/locales/constants/*.rb

--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name = "humanize"
   s.version = "2.5.0"
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
   s.require_paths = ["lib"]
   s.authors = ["Jack Chen", "Ryan Bigg"]
   s.email = "me@ryanbigg.com"


### PR DESCRIPTION
Sorry to reopen PR: https://github.com/radar/humanize/pull/79
But when you pump version and push code to master, my code is lost.
I think run github actions on pull_request is needed.