### PR TITLE
fix: plural for lots in french version

### DIFF
--- a/lib/humanize/locales/fr.rb
+++ b/lib/humanize/locales/fr.rb
@@ -8,7 +8,7 @@ module Humanize
       until number.zero?
         number, remainder = number.divmod(1000)
         unless remainder.zero?
-          add_grouping(parts, iteration)
+          add_grouping(parts, iteration, remainder)
 
           parts << SUB_ONE_GROUPING[remainder] unless exactly_one_thousand?(remainder, parts)
         end
@@ -25,8 +25,16 @@ module Humanize
       remainder == 1 && parts.last.to_s.strip == 'mille'
     end
 
-    def add_grouping(parts, iteration)
-      grouping = LOTS[iteration]
+    def plural_for_lots(remainder, word, iteration)
+      if remainder > 1 && iteration >= 2
+        "#{word}s"
+      else
+        word
+      end
+    end
+
+    def add_grouping(parts, iteration, remainder)
+      grouping = plural_for_lots(remainder, LOTS[iteration], iteration)
       return unless grouping
 
       parts << grouping

--- a/spec/locales/fr_spec.rb
+++ b/spec/locales/fr_spec.rb
@@ -11,7 +11,13 @@ RSpec.describe Humanize, "fr locale" do
     [8.15, 'huit virgule un cinq'],
     [1002, 'mille deux'],
     [2001, 'deux mille un'],
-    [10_000, 'dix mille']
+    [10_000, 'dix mille'],
+    [1_000_000, "un million"],
+    [2_000_000, "deux millions"],
+    [5_000_000, "cinq millions"],
+    [1_000_000_000, "un milliard"],
+    [2_000_000_000, "deux milliards"],
+    [5_000_000_000, "cinq milliards"]
   ]
 
   tests.each do |num, output|


### PR DESCRIPTION
In french when we have multiple million/billion and other big numbers there is an s at the end 🥐 