### PR TITLE
Pure Ruby `s.files` using `Dir[]`

### DIFF
--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -6,9 +6,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.authors = ["Jack Chen", "Ryan Bigg"]
   s.email = "me@ryanbigg.com"
-  s.files = `git ls-files`.split($/)
   s.homepage = "https://github.com/radar/humanize"
   s.summary = "Extension to Numeric to humanize numbers"
+
+  s.files = Dir["lib/**/*"].reject { |f| File.directory?(f) }
+  s.files += ["humanize.gemspec", "LICENSE.md", "README.markdown"]
 
   s.add_development_dependency 'mutant'
   s.add_development_dependency 'mutant-rspec'


### PR DESCRIPTION
Hello! Thanks for considering this change.

This PR replaces the `s.files` value in `humanize.gemspec`, removing the reliance on a system installation of Git. The replacement globs files from `lib` and appends a few other useful files into the built gem.

As a bonus, this should trim back a bit on the published gem size (about 30k in a quick local test).
