### PR TITLE
Add issues and source code metadata to gemspec

### DIFF
--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['bug_tracker_uri'] = "#{s.homepage}/issues"
+  s.metadata['source_code_uri'] = "#{s.homepage}/tree/v#{s.version}"
 end


### PR DESCRIPTION
## Description

The `gemspec` file supports [a bunch of metadata](https://guides.rubygems.org/specification-reference/#metadata). Among that are a couple of `*_uri` methods that RubyGems.org will helpfully show in the sidebar of a page when viewing a gem ([example](https://rubygems.org/gems/link-header-parser)).

This PR adds two of those pieces of metadata:

- `bug_tracker_uri` pointing to the project's GitHub Issues page, and
- `source_code_uri` which dynamically links to the published version's source tree on GitHub.

The latter is most helpful when browsing versions of the gem on RubyGems.org. Having a direct link to that version's tag on GitHub is super handy.

## Future Considerations

At a minimum, I'd like to also add a `changelog_uri` to the gem's metadata. The project doesn't currently have a `CHANGELOG.md` (or similar) and doesn't use GitHub Releases, so I've left that task undone for now. I've used both approaches in the past, but have recently been migrating projects' metadata to point to GitHub Releases pages (similar to the dynamic `source_code_uri` link in this PR).

Obviously this would introduce a process change to the project that, ultimately, would be up to the maintainers. I bring it up here as a gem consumer who's work life is made a good bit easier by having those "Changelog" links on RubyGems.org pages.