### PR TITLE
Add license to gem metadata

### DIFF
--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/)
   s.homepage = "https://github.com/radar/humanize"
   s.summary = "Extension to Numeric to humanize numbers"
+  s.license = 'MIT'
 
   s.add_development_dependency 'mutant'
   s.add_development_dependency 'mutant-rspec'


### PR DESCRIPTION
Does exactly what it says on the tin! RubyGems.org will display the project's license information on the gem's page.

Reference: https://guides.rubygems.org/specification-reference/#metadata
