### PR TITLE
Move development dependencies to `Gemfile`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 5
-# Configuration parameters: EnforcedStyle, AllowedGems, Include.
-# SupportedStyles: Gemfile, gems.rb, gemspec
-# Include: **/*.gemspec, **/Gemfile, **/gems.rb
-Gemspec/DevelopmentDependencies:
-  Exclude:
-    - 'humanize.gemspec'
-
 # Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
 Metrics/AbcSize:

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,9 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'mutant'
+gem 'mutant-rspec'
+gem 'pry-byebug'
+gem 'rspec'
+gem 'rubocop'

--- a/humanize.gemspec
+++ b/humanize.gemspec
@@ -15,11 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"].reject { |f| File.directory?(f) }
   s.files += ["humanize.gemspec", "LICENSE.md", "README.markdown"]
 
-  s.add_development_dependency 'mutant'
-  s.add_development_dependency 'mutant-rspec'
-  s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['bug_tracker_uri'] = "#{s.homepage}/issues"
   s.metadata['source_code_uri'] = "#{s.homepage}/tree/v#{s.version}"


### PR DESCRIPTION
This PR moves the project's development dependencies from its gemspec to `Gemfile` following RuboCop's `Gemspec/DevelopmentDependencies` (rubocop/rubocop#11469) recommendation. There's some debate on that PR over the change, but in the spirit of leaning in to community defaults, this change moves those dependencies.

I'll admit to not knowing this project's maintainers well enough to know whether or not y'all prefer this particular recommendation. If it's undesirable, we can close this one out and/or move the rule's configuration from the todo file to the main `.rubocop.yml` file.