### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,14 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
+        bundler-cache: true
         ruby-version: ${{ matrix.ruby_version }}
-
     - name: Build and test with Rake
       run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
         bundle exec rspec
         bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,9 @@
 name: Ruby
 
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [3.3, 3.2, 3.1]
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,20 +6,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.3"
+      - run: bundle exec rubocop
+  test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [3.3, 3.2, 3.1]
-
-    runs-on: ubuntu-latest
-
+        ruby: [3.3, 3.2, 3.1]
     steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: ${{ matrix.ruby_version }}
-    - name: Build and test with Rake
-      run: |
-        bundle exec rspec
-        bundle exec rubocop
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle exec rspec


### PR DESCRIPTION
This PR refactors the `ruby.yml` GitHub Actions workflow with a handful of changes:

**1. Configure bundler cache in setup-ruby action**

The [ruby/setup-ruby GitHub Action](https://github.com/ruby/setup-ruby) supports a `bundler-cache` config that, "runs 'bundle install' and caches installed gems automatically." Using this configuration simplifies later job steps and speeds up subsequent workflow runs.

**2. Configure `workflow_dispatch` event**

Allows for [manual running of a workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow). Occasionally handy.

**3. Split lint and test jobs into two separate, parallel jobs.**

Since the RuboCop config specifies the target Ruby version (3.1), there _shouldn't_ be a need to run the tool in each tested Ruby.

In this configuration, the linting job will run and report any errors in parallel with the test job(s) defined in the matrix. The previous addition that caches dependencies in the Ruby setup step should make all of this run pretty quick.

**4. Don't fail fast**

This setting allows all jobs in the matrix to continue to completion whether or not any of them fail along the way. This is most useful in cases where, say, Ruby 3.3 fails on an actual error but we'd want to know whether or not the same error appears in Ruby 3.2 and 3.1. Absent this configuration, if the Ruby 3.3 error was encountered first, all jobs would be cancelled without reporting success or failure of the test suite.

---

Thanks for considering this change!