### PR TITLE
Update Mutant configuration

### DIFF
--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,0 +1,10 @@
+includes:
+  - "lib"
+requires:
+  - "humanize"
+integration:
+  name: "rspec"
+matcher:
+  subjects:
+    - "Humanize"
+usage: "opensource"

--- a/README.markdown
+++ b/README.markdown
@@ -150,7 +150,7 @@ Currently supported locales:
 
 Install development dependencies by running `bundle install`.
 
-You can run mutation testing by calling `bin/run_mutant`.
+You can run mutation testing by calling `bundle exec mutant run`.
 
 ## Credits
 

--- a/bin/run_mutant
+++ b/bin/run_mutant
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-mutant --include lib --require humanize --use rspec Humanize


### PR DESCRIPTION
## Description

I'll admit to being fairly new to [mutant](https://github.com/mbj/mutant) and mutation testing in general. I did notice, though, that the README and `bin/run_mutant` shell script didn't jive with recent(ish?) changes to that gem.

As-is, `bundle install`-ing this gem's dependencies and calling `bin/run_mutant` threw a number of errors. Seems there've been quite a few changes in mutant:

- `run` is the appropriate subcommand
- a `usage` flag is now required
- the `--use` flag is now `--integration`
- etc. etc. etc.

This PR refactors the existing configuration to align with that project's current version by adding a `.mutant.yml` file, removing this project's custom shell script, and updating the documentation.

## Testing

1. `git switch update-mutant-configuration`
2. `bundle install`
3. `bundle exec mutant run`

I don't know enough to draw conclusions from the output of the test run, though. But, this change should be okay since mutation testing isn't run as part of `ruby.yml` GitHub Action. Maybe it should be? I dunno. That's beyond the scope of this change.